### PR TITLE
Fix kubectl syntax example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Imagine I want to deploy nginx to a Kubernetes cluster. I'd probably type something like this in my terminal:
 
 ```bash
-kubectl run nginx --image=nginx --replicas=3
+kubectl create deployment nginx --image=nginx --replicas=3
 ```
 
 and hit enter. After a few seconds, I should see three nginx pods spread across all my worker nodes. It works like magic, and that's great! But what's really going on under the hood?


### PR DESCRIPTION
fix typo on example:

``` 
kubectl run nginx --image=nginx --replicas=3

error: unknown flag: --replicas
```

Correct syntax:
```
kubectl create deployment nginx --image=nginx --replicas=3
```

kubectl version:
```
kubectl version
Client Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.3", GitCommit:"816c97ab8cff8a1c72eccca1026f7820e93e0d25", GitTreeState:"clean", BuildDate:"2022-01-25T21:25:17Z", GoVersion:"go1.17.6", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.6+k3s1", GitCommit:"3228d9cb9a4727d48f60de4f1ab472f7c50df904", GitTreeState:"clean", BuildDate:"2022-01-25T01:14:20Z", GoVersion:"go1.16.10", Compiler:"gc", Platform:"linux/arm64"}
```
