### PR TITLE
Fix kubectl syntax example in the zh-cn and ja-jp translations

### DIFF
--- a/ja-jp/README.md
+++ b/ja-jp/README.md
@@ -3,7 +3,7 @@
 nginx を Kubernetes クラスターにデプロイしたいとしましょう。私はおそらくターミナルでつぎのようなコマンドをタイプするでしょう。
 
 ```bash
-kubectl run --image=nginx --replicas=3
+kubectl create deployment --image=nginx --replicas=3
 ```
 
 そしてエンターキーを押します。数秒後、3つの nginx ポッドがすべてのワーカーノードに展開されているのがわかるでしょう。魔法のように動作し、素晴らしいです！しかし、実際のところ何が起こっているのでしょうか。

--- a/zh-cn/README.md
+++ b/zh-cn/README.md
@@ -5,7 +5,7 @@
 想象一下，当你想在 Kubernetes 集群部署 Nginx 时，你会执行以下命令：
 
 ```bash
-kubectl run nginx --image=nginx --replicas=3
+kubectl create deployment nginx --image=nginx --replicas=3
 ```
 
 几秒后，你将看到三个 Nginx Pod 分布在集群工作节点上。这相当神奇，但它背后究竟发生了什么？


### PR DESCRIPTION
Sync the PR #47 to the zh-cn and ja-jp translations.